### PR TITLE
Force SDK version 28 for compile

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -42,7 +42,7 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile) {
 }
 
 android {
-    compileSdkVersion safeExtGet('compileSdkVersion', DEFAULT_COMPILE_SDK_VERSION)
+    compileSdkVersion DEFAULT_COMPILE_SDK_VERSION
     buildToolsVersion safeExtGet('buildToolsVersion', DEFAULT_BUILD_TOOLS_VERSION)
     defaultConfig {
         minSdkVersion safeExtGet('minSdkVersion', DEFAULT_MIN_SDK_VERSION)


### PR DESCRIPTION
This library does not work with compile version > 28, so defaulting to the version of the parent will cause build failures.